### PR TITLE
Rollup >= 0.48 compatibility

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "start": "rollup -c -w"
   },
   "devDependencies": {
-    "rollup": "^0.43.0",
+    "rollup": "^0.48.0",
     "rollup-plugin-fill-html": "^1.0.5",
     "rollup-watch": "^4.0.0"
   }

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -1,9 +1,11 @@
 import html from 'rollup-plugin-fill-html';
 
 export default {
-  entry: 'src/index.js',
-  dest: 'dist/bundle-[hash].js',
-  format: 'iife',
+  input: 'src/index.js',
+  output: {
+    file: 'dist/bundle-[hash].js',
+    format: 'iife',
+  },
   plugins: [
     html({
       template: 'src/index.html',

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -793,11 +793,9 @@ rollup-watch@^4.0.0:
     chokidar "^1.7.0"
     require-relative "0.8.7"
 
-rollup@^0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.43.0.tgz#b36bdb75fa5e0823b6de8aee18ff7b5655520543"
-  dependencies:
-    source-map-support "^0.4.0"
+rollup@^0.48.0:
+  version "0.48.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.48.2.tgz#dd9214eaf78d98a7771bf5583123cc80a0b5d6dc"
 
 safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
@@ -824,16 +822,6 @@ sntp@1.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
-
-source-map-support@^0.4.0:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
-  dependencies:
-    source-map "^0.5.6"
-
-source-map@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
 sshpk@^1.7.0:
   version "1.13.1"

--- a/src/index.js
+++ b/src/index.js
@@ -29,17 +29,17 @@ export default (opt = {}) => {
 		name: 'html',
 		onwrite(config, data) {
 			const tpl = readFileSync(template).toString();
-			const { dest, targets } = config;
+			const { file, targets } = config;
 			const fileList = [];
 			let destPath = '';
 
-			if (dest) {
+			if (file) {
 				// relative('./', dest) will not be equal to dest when dest is a absolute path
-				destPath = relative('./', dest);
+				destPath = relative('./', file);
 			} else if (targets) {
 				for (let i = 0; i < targets.length; i++) {
 					if (format === targets[i].format) {
-						destPath = relative('./', targets[i].dest);
+						destPath = relative('./', targets[i].file);
 					}
 				}
 			}
@@ -54,14 +54,14 @@ export default (opt = {}) => {
 			traverse(firstDir, fileList);
 
 			if (Array.isArray(externals)) {
-        let firstBundle = 0;
-        externals.forEach(function(node) {
-          if (node.pos === 'before') {
-            fileList.splice(firstBundle++, 0, node);
-          } else {
-            fileList.splice(fileList.length, 0, node);
-          }
-        })
+				let firstBundle = 0;
+				externals.forEach(function(node) {
+					if (node.pos === 'before') {
+						fileList.splice(firstBundle++, 0, node);
+					} else {
+						fileList.splice(fileList.length, 0, node);
+					}
+				})
 			}
 
 			fileList.forEach(node => {


### PR DESCRIPTION
As mentioned in #4 this fixes the plugin when using against rollup `>=0.48`. Changes are pretty minimal though breaking as this becomes incompatible with older rollup versions.

- There were no tests to update but you can check that it works by changing the top of 
  `examples/rollup.config.js` to:

```.js
// import html from 'rollup-plugin-fill-html';
import html from '../src/index';
```

- The`rollup-plugin-fill-html` version in `examples/package.json` still needs to be changed once released.
- There seemed to be some mixed-indentation in the source file, which is fixed at the same time (editor did it automatically according to the rest of the file and figured it wouldn't hurt to keep it like that).