### PR TITLE
Fix mapping JS files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ export default (opt = {}) => {
 					let attrs = {src: src};
 					let mode = node.mode || defaultmode;
 					if (mode) attrs.type = mode;
-					attrs = Object.entries(([key, val]) => `${key}="${val}"`).join(' ');
+					attrs = Object.entries(attrs).map(([key, val]) => `${key}="${val}"`).join(' ');
 					const script = `<script ${attrs}></script>\n`;
 					// node.inject will cover the inject
 					if (node.inject === 'head' || inject === 'head') {


### PR DESCRIPTION
I believe there was a typo in https://github.com/alwaysonlinetxm/rollup-plugin-fill-html/pull/9

Without this fix `<script />` tags are empty.