### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export default (opt = {}) => {
 					head.append(`<link rel="stylesheet" href="${src}">\n`);
 				}
 			});
-			writeFileSync(destFile, $.html());
+			writeFileSync(destFile, $.html({ decodeEntities: false }));
 		}
 	};
 }


### PR DESCRIPTION
Non-latin characters get HTML-encoded, to avoid this we need to provide decodeEntities option.